### PR TITLE
Prevent campaigns from producing fatal errors on annotation notifications

### DIFF
--- a/classes/SBW/Campaigns/Notifications.php
+++ b/classes/SBW/Campaigns/Notifications.php
@@ -189,11 +189,11 @@ class Notifications {
 			$return = [];
 		}
 
-		if (!$object instanceof Campaign) {
+		if (!$object instanceof Campaign && $object instanceof ElggObject) {
 			// Notify campaigns subscribers about donations, news items etc contained by the campaign
 			$object = $object->getContainerEntity();
 		}
-		
+
 		if ($object instanceof Campaign) {
 			$dbprefix = elgg_get_config('dbprefix');
 			$query = "


### PR DESCRIPTION
The `SBW\Campaigns\Notifications::getSubscriptions()` callback for the `[get, subscriptions]` plugin hook was not checking the given parameters correctly and was therefore trying to process annotations as entities causing a fatal error.